### PR TITLE
Fix architecture diagram and key features accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,37 @@ Store data with cryptographic provenance on the [Swarm](https://ethswarm.org) de
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│                      Your Application                     │
-├───────────┬───────────────┬──────────────────────────────┤
-│    SDK    │      CLI      │          MCP Server          │
-│  (TS/JS)  │   (Python)    │    (AI agent integration)    │
-└─────┬─────┴───┬───────────┴──────────────┬───────────────┘
-      │         │                          │
-      │    ┌────┴─────┐                    │
-      │    │  Chain    │                   │
-      │    │  Client   │                   │
-      │    └────┬──────┘                   │
-      │         │                          │
-      ▼         │         ▼                ▼
-┌───────────────│───────────────────────────────────┐
-│  Provenance   │    Gateway                        │
-│  (FastAPI  —  │  swarm_connect)                   │
-│               │       │                           │
-│   stamps, upload/download, notary signing         │
-└───────────────│───────┬───────────────────────────┘
-                │       │
-                │       ▼
-                │   Swarm Network
-                │   (decentralized storage)
-                │
-                ▼
-          Blockchain RPC
-          (Base Sepolia)
-     DataProvenance contract
+┌─────────────────────────────────────────────────────────┐
+│                     Your Application                     │
+├──────────────────────────┬──────────────────────────────┤
+│      SDK    │    CLI     │          MCP Server          │
+│     (TS/JS) │  (Python)  │    (AI agent integration)    │
+└───┬─────────┴──┬─────────┴─────────────┬────────────────┘
+    │            │                       │
+    ├────────────┤                       │
+    │    Chain Clients (direct)          │
+    │     (viem / web3.py)              │
+    ├────────────┤                       │
+    │            │                       │
+    │   ┌────────┘          ┌────────────┘
+    │   │                   │
+    ▼   ▼                   ▼
+┌─────────────────────────────────────────────────────────┐
+│                   Provenance Gateway                     │
+│              (FastAPI — swarm_connect)                    │
+│                                                          │
+│       stamps, upload/download, notary signing            │
+└──────────────────────────┬──────────────────────────────┘
+                           │
+                           ▼
+                      Swarm Network
+                  (decentralized storage)
+
+    ── SDK & CLI also connect directly ──
+
+                    Blockchain RPC
+                    (Base Sepolia)
+               DataProvenance contract
 ```
 
 SDK and CLI can anchor data hashes **directly** on-chain via their own chain client.


### PR DESCRIPTION
## Summary

- Fix architecture diagram: blockchain anchoring (chain client) is a direct connection from SDK/CLI to the blockchain RPC, not routed through the gateway
- Show chain client for both SDK and CLI (not just CLI)
- Split key features into "via gateway" vs "direct to blockchain" sections

## Context

The initial README incorrectly showed blockchain sitting behind the gateway. In reality, SDK and CLI each have their own chain client (viem / web3.py) that connects directly to Base Sepolia RPC. The gateway only handles Swarm storage, stamps, and notary signing.