### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+This is the **hub repo** for the Datafund Provenance Toolkit. It contains the overview README and links to individual components — no application code lives here.
+
+## Contributing to a Component
+
+Each component has its own repo, issue tracker, and contribution workflow:
+
+| Component | Repo | Issues |
+|-----------|------|--------|
+| SDK (TypeScript) | [swarm_provenance_SDK](https://github.com/datafund/swarm_provenance_SDK) | [Issues](https://github.com/datafund/swarm_provenance_SDK/issues) |
+| CLI (Python) | [swarm_provenance_CLI](https://github.com/datafund/swarm_provenance_CLI) | [Issues](https://github.com/datafund/swarm_provenance_CLI/issues) |
+| MCP Server | [swarm_provenance_mcp](https://github.com/datafund/swarm_provenance_mcp) | [Issues](https://github.com/datafund/swarm_provenance_mcp/issues) |
+| Gateway | [swarm_connect](https://github.com/datafund/swarm_connect) | [Issues](https://github.com/datafund/swarm_connect/issues) |
+| Landing Page | [provenance-landing](https://github.com/datafund/provenance-landing) | [Issues](https://github.com/datafund/provenance-landing/issues) |
+
+Please open issues and PRs in the relevant repo.
+
+## Contributing to This Hub
+
+Improvements to the README, architecture diagram, or documentation links are welcome here.
+
+**Workflow:**
+
+1. Fork the repo
+2. Create a branch from `development`
+3. Make your changes
+4. Open a PR targeting `development`
+
+The `main` branch is protected and requires a review to merge.
+
+## Reporting Issues
+
+- **Toolkit-wide feedback** (e.g. missing components, incorrect overview) → [open an issue here](https://github.com/datafund/provenance/issues)
+- **Component-specific bugs or features** → use the component repo's issue tracker (see table above)


### PR DESCRIPTION
## Summary

- Add lightweight contributing guide that points to each component's repo and issue tracker
- Documents branch workflow for hub contributions (fork → branch from `development` → PR)

Closes #4